### PR TITLE
simplify `int.from_bytes(data, 'big')` + other

### DIFF
--- a/libraries/packing.py
+++ b/libraries/packing.py
@@ -2,20 +2,22 @@ import numpy as np
 import math
 
 
-def pack(polycube: np.ndarray) -> int:
+def pack(polycube: np.ndarray) -> bytes:
     """
-    Converts a 3D ndarray into a single unsigned integer for quick hashing and efficient storage
-
-    Converts a {0,1} nd array into a single unique large integer
+    Converts a 3D ndarray into a single bytes object that unique identifies 
+    the polycube, is hashable, comparable, and allows to reconstruct the 
+    original polycube ndarray.
 
     Parameters:
-    polycube (np.array): 3D Numpy byte array where 1 values indicate polycube positions
+    polycube (np.array): 3D Numpy byte array where 1 values indicate polycube positions,
+        and 0 values indicate empty space. Must be of type np.int8.
 
     Returns:
-    int: a unique integer hash
+    cube_id (bytes): a bytes representation of the polycube
 
     """
 
+    # # Previous implementation:
     # pack_cube = np.packbits(polycube.flatten(), bitorder='big')
     # cube_hash = 0
     # for index in polycube.shape:
@@ -24,31 +26,34 @@ def pack(polycube: np.ndarray) -> int:
     #     cube_hash = (cube_hash << 8) + int(part)
     # return cube_hash
 
-    data = polycube.tobytes() + polycube.shape[0].to_bytes(1, 'big') + polycube.shape[1].to_bytes(1, 'big') + polycube.shape[2].to_bytes(1, 'big')
-    return int.from_bytes(data, 'big')
+    # # dtype should be np.int8: (commented out for efficiency)
+    # if polycube.dtype != np.int8:
+    #     raise TypeError("Polycube must be of type np.int8")
+
+    # pack cube
+    data = polycube.tobytes() + polycube.shape[0].to_bytes(1, 'big') \
+                              + polycube.shape[1].to_bytes(1, 'big') \
+                              + polycube.shape[2].to_bytes(1, 'big')
+    return data
 
 
-def unpack(cube_hash: int) -> np.ndarray:
+def unpack(cube_id: bytes) -> np.ndarray:
     """
-    Converts a single integer back into a 3D ndarray
-
+    Converts a bytes object back into a 3D ndarray
 
     Parameters:
-    cube_hash (int): a unique integer hash
+    cube_id (bytes): a unique bytes object
 
     Returns:
-    np.array: 3D Numpy byte array where 1 values indicate polycube positions
-
+    polycube (np.array): 3D Numpy byte array where 1 values indicate 
+        cube positions
+        
     """
+    # Extract shape information
+    shape = (cube_id[-3], cube_id[-2], cube_id[-1])
 
-    length = math.ceil(math.log2(cube_hash))
-    parts = cube_hash.to_bytes(length, byteorder='big')
-    shape = (
-        parts[-3],
-        parts[-2],
-        parts[-1],
-    )
-    size = shape[0] * shape[1] * shape[2]
-    raw = np.frombuffer(parts[:-3], dtype=np.uint8)
-    final = raw[(len(raw) - size):len(raw)].reshape(shape)
-    return final
+    # Create ndarray from byte data
+    polycube = np.frombuffer(cube_id[:-3], dtype=np.int8)
+    polycube = polycube.reshape(shape)
+    return polycube
+


### PR DESCRIPTION
Implements this comment: https://github.com/mikepound/opencubes/pull/3#discussion_r1261848089

- replaced unnecessary `int.from_bytes(data, 'big')` with just `data`
- `cube_hash` is now not an `int` but `bytes`

- change naming: cube_hash to cube_id

- typo correction: get_canoincal_packing

- relevant docstring updates
